### PR TITLE
Fix issue in importing Idaho OpenStates data from JSON.

### DIFF
--- a/lib/tasks/openstates.rake
+++ b/lib/tasks/openstates.rake
@@ -134,7 +134,7 @@ namespace :openstates do
                # Modify the downloaded JSON document to force _id to be the same as id
                mongo_doc_copy = "#{mongo_doc}.orig"
                FileUtils.mv(mongo_doc, mongo_doc_copy)
-               File.open(mongo_doc, 'w') { |f| f.write(File.read(mongo_doc_copy).gsub(/"id"/, "\"_id\": \"#{json_id}\", \"id\"")) }
+               File.open(mongo_doc, 'w') { |f| f.write(File.read(mongo_doc_copy).gsub(/"id":/, "\"_id\": \"#{json_id}\", \"id\":")) }
                FileUtils.rm_rf(mongo_doc_copy)
 
                # Import the document into MongoDB

--- a/lib/tasks/openstates.rake
+++ b/lib/tasks/openstates.rake
@@ -144,7 +144,11 @@ namespace :openstates do
                mongoimport = "mongoimport --stopOnError #{db.connection_options} -c #{zip_dir_name} --type json --file \"#{mongo_doc}\" --drop"
 
                rc = system("#{mongoimport} 1>/dev/null")
-               abort "mongoimport failed: #{mongoimport}" unless rc
+               unless rc
+                 puts mongoimport
+                 system("#{mongoimport}")
+                 abort
+               end
 
                File.delete(mongo_doc) if File.exists?(mongo_doc)
              end

--- a/lib/tasks/openstates.rake
+++ b/lib/tasks/openstates.rake
@@ -141,7 +141,7 @@ namespace :openstates do
                # Assume directory name maps to MongoDB collection name
                # http://docs.mongodb.org/manual/reference/program/mongoimport/
                # http://docs.mongodb.org/manual/core/import-export/
-               mongoimport = "mongoimport --stopOnError #{db.connection_options} -c #{zip_dir_name} --type json --file \"#{mongo_doc}\" --drop"
+               mongoimport = "mongoimport --stopOnError #{db.connection_options} -c #{zip_dir_name} --type json --file \"#{mongo_doc}\" --upsert"
 
                rc = system("#{mongoimport} 1>/dev/null")
                unless rc


### PR DESCRIPTION
JSON attributes with value "id" mistakenly substituted.
Changed mongoimport error handling to show stderr upon failure.
