### PR TITLE
Move to 1 db

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,19 +10,12 @@
 
 Install or update dependencies:
 
-    rvm 1.9.3
+    rvm 1.9.3 # i.e. switch to ruby 1.9.3, your steps may vary
     bundle
 
 Start the server:
 
     rails server
-
-## Pulling Data
-
-Get the latest data from OpenStates (in development only):
-
-    ./script/openstates.sh
-    rake db:mongoid:create_indexes
 
 ### Setting Up API Keys
 
@@ -34,6 +27,15 @@ In production, you should set `SUNLIGHT_API_KEY` and `PROJECT_VOTE_SMART_API_KEY
 
     heroku config:add SUNLIGHT_API_KEY=...
     heroku config:add PROJECT_VOTE_SMART_API_KEY=...
+
+## Pulling Data (in development only)
+
+Get the necessary supporting data (work-in-progress, will change):
+
+    bundle exec rake openstates:json:update
+    bundle exec rake openstates:add_metadata
+    bundle exec rake congres:api:download:legislators
+    bundle exec rake db:mongoid:create_indexes
 
 ### Influence Explorer
 

--- a/README.md
+++ b/README.md
@@ -8,16 +8,23 @@
 
 ## Getting Started
 
-Install or update dependencies:
+We require these to be installed:
+
+* imagemagick
+* nodejs
+* mongodb # should also be running
+* redis # should also be running
+
+Depending on your OS , you may also need to install these:
+
+* libxml2-dev
+* libxslt-dev
+* libmagickwand-dev
+
+In the application's directory, set up Ruby 1.9.3 and required gems:
 
     rvm 1.9.3 # i.e. switch to ruby 1.9.3, your steps may vary
     bundle
-    libxml2-dev
-    libxslt-dev
-    imagemagick 
-    libmagickwand-dev
-    mongodb
-    nodejs
 
 Start the server:
 

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -45,7 +45,7 @@ class PeopleController < ApplicationController
   end
 
   def end_of_association_chain
-    Person.in(parent.abbreviation)
+    Person.connected_to(parent.abbreviation)
   end
 
   def collection

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -24,12 +24,12 @@ class QuestionsController < ApplicationController
     @question.user = user_signed_in? ? current_user : User.new
 
     if params[:person]
-      @person = Person.in(@state_code).find(params[:person])
+      @person = Person.connected_to(@state_code).find(params[:person])
       @question.person = @person
     end
 
     if params[:bill]
-      @bill = Bill.in(@state_code).find(params[:bill])
+      @bill = Bill.connected_to(@state_code).find(params[:bill])
       @question.bill = @bill
     end
 
@@ -87,7 +87,7 @@ class QuestionsController < ApplicationController
     questions = Question.where(state: parent.abbreviation)
     return questions unless type == 'FederalLegislator'
 
-    person_ids = FederalLegislator.in(parent.abbreviation).collect(&:id)
+    person_ids = FederalLegislator.connected_to(parent.abbreviation).collect(&:id)
     questions.where(person_ids: { '$in' => person_ids })
   end
 

--- a/app/controllers/subjects_controller.rb
+++ b/app/controllers/subjects_controller.rb
@@ -16,7 +16,7 @@ private
 
   # @note MT, RI and WI have inconsistent subject names (typos, etc.).
   def chain
-    Bill.in(parent.abbreviation)
+    Bill.connected_to(parent.abbreviation)
   end
 
   def collection

--- a/app/models/bill.rb
+++ b/app/models/bill.rb
@@ -98,7 +98,7 @@ class Bill
     # Get all the legislator sponsors in a single query.
     ids = sponsors.select{|x| x['leg_id']}.map{|x| x['leg_id']}
     unless ids.empty?
-      criteria = Person.use(read_attribute(:state)).where(_id: {'$in' => ids})
+      criteria = Person.where(_id: {'$in' => ids})
       if opts[:eager]
         criteria = criteria.includes(:questions)
       end
@@ -110,7 +110,7 @@ class Bill
     # Get all the committee sponsors in a single query.
     ids = sponsors.select{|x| x['committee_id']}.map{|x| x['committee_id']}
     unless ids.empty?
-      Committee.use(read_attribute(:state)).where(_id: {'$in' => ids}).each do |document|
+      Committee.where(_id: {'$in' => ids}).each do |document|
         documents_by_id[document.id] = document
       end
     end

--- a/app/models/bill_detail.rb
+++ b/app/models/bill_detail.rb
@@ -1,7 +1,6 @@
 # Exists only because we blow away the `bills` collection regularly.
 class BillDetail
   include Mongoid::Document
-  store_in session: 'default' # @see https://github.com/mongoid/mongoid/pull/2909
 
   # The bill's jurisdiction.
   field :state, type: String
@@ -21,11 +20,15 @@ class BillDetail
     Metadatum.find_by_abbreviation(state)
   end
 
+  # @todo delete if unnecessary with only 1 db
+  # i.e. does belongs_to now work
   # @return [Bill] the bill
   def bill
-    Bill.use(state).find(bill_id)
+    Bill.find(bill_id)
   end
 
+  # @todo delete if unnecessary with only 1 db
+  # i.e. does belongs_to now work (with delegate state to bill)
   # @param [Bill] bill a bill
   def bill=(bill)
     if bill

--- a/app/models/committee.rb
+++ b/app/models/committee.rb
@@ -21,7 +21,7 @@ class Committee
     if ids.empty?
       []
     else
-      Person.use(read_attribute(:state)).where(_id: {'$in' => ids}).to_a
+      Person.where(_id: {'$in' => ids}).to_a
     end
   end
 end

--- a/app/models/federal_legislator.rb
+++ b/app/models/federal_legislator.rb
@@ -139,7 +139,7 @@ class FederalLegislator < Person
   end
 
   def self.build_from_api(attributes)
-    federal_legislator = with(session: 'openstates').new
+    federal_legislator = new
     federal_legislator.attributes_from_congress_api attributes
     federal_legislator
   end

--- a/app/models/metadatum.rb
+++ b/app/models/metadatum.rb
@@ -16,7 +16,7 @@ class Metadatum
   field :abbreviation, type: String
 
   def self.find_by_abbreviation(abbreviation)
-    self.use(abbreviation).find(abbreviation)
+    self.find(abbreviation)
   end
 
   # Returns whether the jurisdiction has a lower chamber.

--- a/app/models/metadatum/state.rb
+++ b/app/models/metadatum/state.rb
@@ -2,11 +2,8 @@
 # for all states jurisdictions
 # includes District of Columbia and Puerto Rico
 class Metadatum::State
-  OPENSTATES_SESSION = 'openstates'
-
   def self.create_states_if_none
-    has_states = Metadatum.with(session: OPENSTATES_SESSION)
-      .nin(abbreviation: Metadatum::Us::ABBREVIATION)
+    has_states = Metadatum.nin(abbreviation: Metadatum::Us::ABBREVIATION)
       .collect(&:abbreviation).sort
 
     unless has_states == OpenGovernment::STATES.values.sort
@@ -18,7 +15,7 @@ class Metadatum::State
     # get the metadatum in one go
     attributes = JSON.parse(results_from_api)
     attributes.each do |attributes|
-      Metadatum.with(session: OPENSTATES_SESSION).create! attributes
+      Metadatum.create! attributes
     end
   end
 
@@ -44,5 +41,5 @@ class Metadatum::State
     RestClient.get api_base_url, params: params
   end
 
-  private_class_method :results_from_api, :api_fields, :api_base_url, :api_key
+  private_class_method :results_from_api, :api_fields, :api_base_url
 end

--- a/app/models/metadatum/us.rb
+++ b/app/models/metadatum/us.rb
@@ -5,7 +5,7 @@ class Metadatum::Us
 
   # return US jurisidiction
   def self.find_or_create!
-    Metadatum.use(ABBREVIATION).where(abbreviation: ABBREVIATION).first ||
+    Metadatum.where(abbreviation: ABBREVIATION).first ||
       create_us_metadatum
   end
 
@@ -17,7 +17,7 @@ class Metadatum::Us
       legislature_name: "United States Congress"
     }
 
-    Metadatum.with(session: 'openstates').create! attributes
+    Metadatum.create! attributes
   end
 
   private_class_method :create_us_metadatum

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -70,7 +70,7 @@ class Person
 
   # for now, only run if we have a clean slate
   def self.load_from_apis_for_jurisdiction(abbreviation)
-    return if self.in(abbreviation).count > 0
+    return if self.connected_to(abbreviation).count > 0
 
     api_parse(results_for_jurisdiction(abbreviation)).map do |attributes|
       create_from_apis attributes
@@ -107,7 +107,7 @@ class Person
 
   # TODO: add spec
   def jurisdiction
-    Metadatum.with(session: 'openstates').find_by_abbreviation(state)
+    Metadatum.find_by_abbreviation(state)
   end
 
   # TODO: add spec
@@ -145,12 +145,14 @@ class Person
 
   # Returns the person's sponsored bills.
   def bills
-    Bill.use(read_attribute(:state)).where('sponsors.leg_id' => id)
+    Bill.where('sponsors.leg_id' => id)
   end
 
   # Returns the person's votes.
   def votes
-    Vote.use(read_attribute(:state)).or({'yes_votes.leg_id' => id}, {'no_votes.leg_id' => id}, {'other_votes.leg_id' => id}) # no index
+    Vote.or({'yes_votes.leg_id' => id},
+            {'no_votes.leg_id' => id},
+            {'other_votes.leg_id' => id}) # no index
   end
 
   # Returns the person's committees.
@@ -159,7 +161,7 @@ class Person
     if ids.empty?
       []
     else
-      Committee.use(read_attribute(:state)).where(_id: {'$in' => ids}).to_a
+      Committee.where(_id: {'$in' => ids}).to_a
     end
   end
 
@@ -242,7 +244,7 @@ class Person
   end
 
   def self.build_from_api(attributes)
-    person = with(session: 'openstates').new(attributes)
+    person = new(attributes)
     # id cannot be mass assigned..., have to set it explictly
     person.id = attributes['id']
     person

--- a/app/models/person_detail.rb
+++ b/app/models/person_detail.rb
@@ -2,7 +2,6 @@
 # @note Based on Popolo.
 class PersonDetail
   include Mongoid::Document
-  store_in session: 'default' # @see https://github.com/mongoid/mongoid/pull/2909
 
   # Links to pages about this person, e.g. Wikipedia, or to accounts this
   # person has on other websites, e.g. Twitter.
@@ -30,7 +29,7 @@ class PersonDetail
 
   # @return [Person] the person
   def person
-    Person.use(state).find(person_id)
+    Person.find(person_id)
   end
 
   # @param [Person] person a person

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -1,7 +1,6 @@
 class Question
   include Mongoid::Document
   include Mongoid::Timestamps
-  store_in session: 'default' # @see https://github.com/mongoid/mongoid/pull/2909
 
   # The author of the question.
   belongs_to :user
@@ -49,11 +48,16 @@ class Question
     Metadatum.find_by_abbreviation(state)
   end
 
+  # @todo delete if unnecessary with only 1 db
+  # i.e. does belongs_to now work
   # @return [Person] the person to whom the question is addressed
   def person
-    Person.use(state).find(person_id)
+    Person.find(person_id)
   end
 
+  # @todo delete if unnecessary with only 1 db
+  # i.e. does belongs_to now work
+  # and delegation of state and person_state to Person
   # @param [Person] person a person
   def person=(person)
     if person
@@ -65,11 +69,16 @@ class Question
     end
   end
 
+  # @todo delete if unnecessary with only 1 db
+  # i.e. does belongs_to now work
   # @return [Bill] the bill the question is about
   def bill
-    Bill.use(state).find(bill_id)
+    Bill.find(bill_id)
   end
 
+  # @todo delete if unnecessary with only 1 db
+  # i.e. does belongs_to now work
+  # and delegation of state and person_state to Person
   # @param [Bill] bill a bill
   def bill=(bill)
     if bill
@@ -81,7 +90,7 @@ class Question
     end
   end
 
-private
+  private
   def state_must_be_included_in_the_list_of_states
     unless state.blank? || Metadatum.find_by_abbreviation(state)
       errors.add(:state, 'is not included in the list of states')

--- a/app/models/rating.rb
+++ b/app/models/rating.rb
@@ -45,7 +45,7 @@ class Rating
 
   # @return [Person] the person being rated
   def person
-    Person.with(session: 'openstates').where(votesmart_id: candidateId).first || # no index
+    Person.where(votesmart_id: candidateId).first || # no index
       PersonDetail.where(votesmart_id: candidateId).first.person
   end
 end

--- a/app/models/signature.rb
+++ b/app/models/signature.rb
@@ -1,7 +1,6 @@
 class Signature
   include Mongoid::Document
   include Mongoid::Timestamps
-  store_in session: 'default' # @see https://github.com/mongoid/mongoid/pull/2909
 
   belongs_to :user
   belongs_to :question

--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -2,7 +2,7 @@ class Subject
   # @return [Array<String>] the list of OpenStates subjects
   # @see https://github.com/sunlightlabs/openstates/wiki/Categorization#subjects
   # alternatively we could populate this
-  # with Bill.with(session: 'openstates').distinct('subject').sort
+  # with Bill.distinct('subject').sort
   def self.all
     [ # In both OpenStates and VoteSmart:     # Additional VoteSmart subjects:
       'Agriculture and Food',

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,5 @@
 class User
   include Mongoid::Document
-  store_in session: 'default' # @see https://github.com/mongoid/mongoid/pull/2909
 
   # Devise
 

--- a/app/models/vote.rb
+++ b/app/models/vote.rb
@@ -17,7 +17,7 @@ class Vote
     if ids.empty?
       []
     else
-      Person.use(read_attribute(:state)).where(_id: {'$in' => ids}).to_a
+      Person.where(_id: {'$in' => ids}).to_a
     end
   end
 end

--- a/config/initializers/mongoid.rb
+++ b/config/initializers/mongoid.rb
@@ -4,22 +4,11 @@
 #
 # @see https://github.com/mongoid/mongoid/pull/2909
 Mongoid::Document::ClassMethods.class_eval do
-  # Sets the appropriate MongoDB session to access a jurisdiction's data.
-  #
-  # @param [String] abbreviation a jurisdiction's abbreviation
-  def use(abbreviation)
-    if abbreviation && abbreviation[/\A[a-z]{2}\z/]
-      with(session: 'openstates')
-    else
-      with(session: nil)
-    end
-  end
-
   # Scopes the collection to the jurisdiction.
   #
   # @param [String] abbreviation a jurisdiction's abbreviation
-  def in(abbreviation)
-    use(abbreviation).where(state: abbreviation)
+  def connected_to(abbreviation)
+    where(state: abbreviation)
   end
 end
 

--- a/config/mongoid.yml
+++ b/config/mongoid.yml
@@ -5,34 +5,16 @@ development:
     default:
       # Defines the name of the default database that Mongoid can connect to.
       # (required).
-      database: opengovernment_local
       # Provides the hosts the default session can connect to. Must be an array
       # of host:port pairs. (required)
       hosts:
+        # - dev.mongo.opengovernment.org
         - localhost:27017
       options:
         # Change whether the session persists in safe mode by default.
         # (default: false)
         safe: true
 
-        # Change the default consistency model to :eventual or :strong.
-        # :eventual will send reads to secondaries, :strong sends everything
-        # to master. (default: :eventual)
-        # consistency: :eventual
-
-        # How many times Moped should attempt to retry an operation after
-        # failure. (default: 30)
-        # max_retries: 30
-
-        # The time in seconds that Moped should wait before retrying an
-        # operation on failure. (default: 1)
-        # retry_interval: 1
-    openstates:
-      database: fiftystates
-      hosts:
-        - localhost:27017
-      options:
-        safe: true
   # Configure Mongoid specific options. (optional)
   options:
     # Configuration for whether or not to allow access to fields that do
@@ -75,7 +57,7 @@ development:
 test:
   sessions:
     default:
-      database: open_government_test
+      database: ask_them_test
       hosts:
         - localhost:27017
       options:
@@ -84,16 +66,7 @@ test:
         # low amounts for fast failures.
         max_retries: 1
         retry_interval: 0
-    openstates:
-      database: open_government_test_fiftystates
-      hosts:
-        - localhost:27017
-      options:
-        consistency: :strong
-        max_retries: 1
-        retry_interval: 0
-<% default = URI.parse(ENV['MONGOHQ_URL'] || ENV['MONGOLAB_URI'] || 'mongodb://127.0.0.1:27017/opengovernment_local') %> # https://gist.github.com/2588954
-<% openstates = URI.parse(ENV['MONGO_URL'] || 'mongodb://127.0.0.1:27017/fiftystates') %> # https://gist.github.com/2588954
+<% default = URI.parse(ENV['MONGO_URL'] || 'mongodb://127.0.0.1:27017/ask_them') %> # https://gist.github.com/2588954
 production:
   sessions:
     default:
@@ -106,18 +79,6 @@ production:
 <% end %>
       hosts:
       - <%= default.host %>:<%= default.port %>
-      options:
-        safe: true
-    openstates:
-      database: <%= openstates.path.sub '/', '' %>
-<% if openstates.user %>
-      username: <%= openstates.user %>
-<% end %>
-<% if openstates.password %>
-      password: <%= openstates.password %>
-<% end %>
-      hosts:
-      - <%= openstates.host %>:<%= openstates.port %>
       options:
         safe: true
   options:

--- a/config/mongoid.yml
+++ b/config/mongoid.yml
@@ -5,6 +5,7 @@ development:
     default:
       # Defines the name of the default database that Mongoid can connect to.
       # (required).
+      database: ask_them_development
       # Provides the hosts the default session can connect to. Must be an array
       # of host:port pairs. (required)
       hosts:

--- a/config/mongoid.yml
+++ b/config/mongoid.yml
@@ -5,7 +5,7 @@ development:
     default:
       # Defines the name of the default database that Mongoid can connect to.
       # (required).
-      database: ask_them_development
+      database: askthem_development
       # Provides the hosts the default session can connect to. Must be an array
       # of host:port pairs. (required)
       hosts:
@@ -63,7 +63,7 @@ development:
 test:
   sessions:
     default:
-      database: ask_them_test
+      database: askthem_test
       hosts:
         - localhost:27017
       options:
@@ -78,7 +78,7 @@ test:
         - localhost:27017
       options:
         safe: true
-<% default = URI.parse(ENV['MONGO_URL'] || 'mongodb://127.0.0.1:27017/ask_them') %> # https://gist.github.com/2588954
+<% default = URI.parse(ENV['MONGO_URL'] || 'mongodb://127.0.0.1:27017/askthem') %> # https://gist.github.com/2588954
 <% scraped_local_gov = URI.parse(ENV['SCRAPED_LOCAL_GOV_URL'] || 'mongodb://127.0.0.1:27017/scraped_local_gov') %>
 production:
   sessions:

--- a/lib/tasks/influenceexplorer.rake
+++ b/lib/tasks/influenceexplorer.rake
@@ -15,10 +15,10 @@ namespace :influenceexplorer do
       not_found_urls = []
 
       criteria = Person.where(transparencydata_id: {'$nin' => ['', nil]}).asc(:transparencydata_id) # no index
-      progressbar = ProgressBar.create(format: '%a |%B| %p%% %e', length: 80, smoothing: 0.5, total: criteria.with(session: 'openstates').count)
+      progressbar = ProgressBar.create(format: '%a |%B| %p%% %e', length: 80, smoothing: 0.5, total: criteria.count)
 
       index = 0
-      people = criteria.clone.with(session: 'openstates').limit(100)
+      people = criteria.clone.limit(100)
 
       while people.any?
         people.each do |person|
@@ -38,7 +38,7 @@ namespace :influenceexplorer do
         end
 
         index += 100
-        people = criteria.clone.with(session: 'openstates').limit(100).skip(index)
+        people = criteria.clone.limit(100).skip(index)
       end
 
       puts not_found_urls

--- a/lib/tasks/openstates.rake
+++ b/lib/tasks/openstates.rake
@@ -1,13 +1,10 @@
 # @see http://sunlightlabs.github.io/openstates-api/
 # @see https://github.com/sunlightlabs/billy/wiki/Differences-between-the-API-and-MongoDB
 namespace :openstates do
-
-  def openstates
+  def with_api_key
     if Metadatum::State.api_key
-      Mongoid.override_session(Metadatum::State::OPENSTATES_SESSION)
       yield
-      Mongoid.override_session(nil)
-    else
+   else
       abort "Metadatum::State.api_key is not set"
     end
   end
@@ -52,7 +49,7 @@ namespace :openstates do
 
   desc 'Update metadata, legislators, committees and bills from OpenStates'
   task update: :environment do
-    openstates do
+    with_api_key do
       # @todo mixed strategy using both JSON downloads and API
     end
   end
@@ -62,7 +59,7 @@ namespace :openstates do
     task download: :environment do
       Mongoid.raise_not_found_error = false
 
-      openstates do
+      with_api_key do
         begin
           metadata = RestClient.get(metadata_url)
         rescue Exception => e
@@ -93,9 +90,9 @@ namespace :openstates do
       require 'find'
       require 'fileutils'
 
-      db = OpenstatesDatabase.new('session' => Metadatum::State::OPENSTATES_SESSION)
+      db = OpenstatesDatabase.new
 
-      openstates do
+      with_api_key do
 
         # Process each zip file we have
         Dir.glob("#{tmp_dir}/*.zip").each do |zip_file|
@@ -168,7 +165,7 @@ namespace :openstates do
   namespace :api do
     desc 'Update metadata from OpenStates API'
     task metadata: :environment do
-      openstates do
+      with_api_key do
         # @todo 1 call
       end
     end
@@ -176,21 +173,21 @@ namespace :openstates do
 
     desc 'Update legislators from OpenStates API'
     task legislators: :environment do
-      openstates do
+      with_api_key do
         # @todo 1 call per state
       end
     end
 
     desc 'Update committees from OpenStates API'
     task committees: :environment do
-      openstates do
+      with_api_key do
         # @todo 1 call
       end
     end
 
     desc 'Update bills from OpenStates API'
     task bills: :environment do
-      openstates do
+      with_api_key do
         # @todo use updated_since
         # complete docs at https://github.com/sunlightlabs/billy/wiki/Differences-between-the-API-and-MongoDB
       end

--- a/spec/models/bill_detail_spec.rb
+++ b/spec/models/bill_detail_spec.rb
@@ -5,23 +5,23 @@ describe BillDetail do
     it {should validate_presence_of attribute}
   end
 
-  context 'with two sessions' do
+  context 'when in relation' do
     before :each do
-      @metadatum = Metadatum.with(session: 'openstates').create(abbreviation: 'zz')
-      @bill = Bill.with(session: 'openstates').create(state: 'zz')
-      @record = BillDetail.with(session: 'default').create(bill: @bill)
+      @metadatum = Metadatum.create(abbreviation: 'zz')
+      @bill = Bill.create(state: 'zz')
+      @record = BillDetail.create(bill: @bill)
     end
 
-    it "should retrieve a metadatum from the OpenStates session for a bill detail in the default session" do
-      BillDetail.with(session: 'default').last.metadatum.should == @metadatum
+    it 'should retrieve a metadatum for a bill detail' do
+      BillDetail.last.metadatum.should == @metadatum
     end
 
-    it "should retrieve a bill's details from the default session for a bill in the OpenStates session" do
-      Bill.with(session: 'openstates').last.bill_detail.should == @record
+    it "should retrieve a bill's bill detail" do
+      Bill.last.bill_detail.should == @record
     end
 
-    it "should retrieve a bill from the OpenStates session for a bill detail in the default session" do
-      BillDetail.with(session: 'default').last.bill.should == @bill
+    it "should retrieve the bill detail's bill" do
+      BillDetail.last.bill.should == @bill
     end
   end
 end

--- a/spec/models/federal_legislator_spec.rb
+++ b/spec/models/federal_legislator_spec.rb
@@ -80,21 +80,21 @@ describe FederalLegislator do
   describe '.for_location' do
     before :each do
       # convoluted setting of id necessary, otherwise id gets generated
-      @federal_legislator = FederalLegislator.with(session: 'openstates').new(state: 'vt')
+      @federal_legislator = FederalLegislator.new(state: 'vt')
       @federal_legislator.id = 'S000033'
       @federal_legislator.save!
     end
 
     it 'returns matching people given a location', :vcr do
       address = '2227 Paine Turnpike South, Berlin, VT'
-      expect(FederalLegislator.with(session: 'openstates').for_location(address).first).to eq @federal_legislator
+      expect(FederalLegislator.for_location(address).first).to eq @federal_legislator
     end
   end
 
   describe '.load_from_api_for_jurisdiction' do
     it 'loads people into database given a state abbreviation', :vcr do
-      FederalLegislator.with(session: 'openstates').load_from_apis_for_jurisdiction('vt')
-      expect(FederalLegislator.with(session: 'openstates').count).to eq 3
+      FederalLegislator.load_from_apis_for_jurisdiction('vt')
+      expect(FederalLegislator.count).to eq 3
     end
   end
 end

--- a/spec/models/influence_explorer_person_detail_spec.rb
+++ b/spec/models/influence_explorer_person_detail_spec.rb
@@ -3,13 +3,13 @@ require 'spec_helper'
 
 describe InfluenceExplorerPersonDetail do
   before :each do
-    @metadatum = Metadatum.with(session: 'openstates').create(abbreviation: 'vt')
+    @metadatum = Metadatum.create(abbreviation: 'vt')
 
     # convoluted setting of id necessary, otherwise id gets generated
     person_params = { state: 'vt',
       transparencydata_id: 'fd638c2fb8b54d0bbc8b13ec32343930' }
 
-    @person = Person.with(session: 'openstates').new(person_params)
+    @person = Person.new(person_params)
     @person.id = 'VTL000008'
     @person.save!
   end

--- a/spec/models/metadatum/state_spec.rb
+++ b/spec/models/metadatum/state_spec.rb
@@ -7,15 +7,14 @@ describe Metadatum::State do
       before :each do
         @metadata = []
         OpenGovernment::STATES.each do |key, value|
-          @metadata << Metadatum.with(session: 'openstates')
-            .create(name: key, abbreviation: value)
+          @metadata << Metadatum.create(name: key, abbreviation: value)
 
         end
       end
 
       it 'does nothing because there is existing state Metadatum' do
         Metadatum::State.create_states_if_none
-        metadata_count = Metadatum.with(session: 'openstates').count
+        metadata_count = Metadatum.count
         expect(metadata_count).to eq @metadata.size
       end
     end
@@ -23,7 +22,7 @@ describe Metadatum::State do
     context 'when no state jurisdictions exist' do
       it 'creates a Metadatum with the states jurisdiction attributes', :vcr do
         Metadatum::State.create_states_if_none
-        metadata_count = Metadatum.with(session: 'openstates').count
+        metadata_count = Metadatum.count
         expect(metadata_count).to eq OpenGovernment::STATES.size
       end
     end
@@ -32,7 +31,7 @@ describe Metadatum::State do
   describe '.create_states_from_api' do
     it 'creates states from api attributes', :vcr do
       Metadatum::State.create_states_from_api
-      metadata_count = Metadatum.with(session: 'openstates').count
+      metadata_count = Metadatum.count
       expect(metadata_count).to eq OpenGovernment::STATES.size
     end
   end

--- a/spec/models/metadatum/us_spec.rb
+++ b/spec/models/metadatum/us_spec.rb
@@ -5,8 +5,7 @@ describe Metadatum::Us do
   describe '.find_or_create!' do
     context 'when a US jurisdiction already exists' do
       before :each do
-        @metadatum = Metadatum.with(session: 'openstates')
-          .create(abbreviation: 'us')
+        @metadatum = Metadatum.create(abbreviation: 'us')
       end
 
       it 'returns existing US jurisdiction' do

--- a/spec/models/person_detail_retriever_spec.rb
+++ b/spec/models/person_detail_retriever_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 
 describe PersonDetailRetriever do
   before :each do
-    @metadatum = Metadatum.with(session: 'openstates').create(abbreviation: 'vt')
+    @metadatum = Metadatum.create(abbreviation: 'vt')
 
     # convoluted setting of id necessary, otherwise id gets generated
     person_params = { state: 'vt',
@@ -12,7 +12,7 @@ describe PersonDetailRetriever do
       district: 'Chittenden',
       transparencydata_id: 'fd638c2fb8b54d0bbc8b13ec32343930' }
 
-    @person = Person.with(session: 'openstates').new(person_params)
+    @person = Person.new(person_params)
     @person.id = 'VTL000001'
     @person.stub :chamber, 'upper'
     @person.save!

--- a/spec/models/person_detail_spec.rb
+++ b/spec/models/person_detail_spec.rb
@@ -5,23 +5,23 @@ describe PersonDetail do
     it {should validate_presence_of attribute}
   end
 
-  context 'with two sessions' do
+  context 'when in relation' do
     before :each do
-      @metadatum = Metadatum.with(session: 'openstates').create(abbreviation: 'zz')
-      @person = Person.with(session: 'openstates').create(state: 'zz')
-      @record = PersonDetail.with(session: 'default').create(person: @person)
+      @metadatum = Metadatum.create(abbreviation: 'zz')
+      @person = Person.create(state: 'zz')
+      @record = PersonDetail.create(person: @person)
     end
 
-    it "should retrieve a metadatum from the OpenStates session for a person detail in the default session" do
-      PersonDetail.with(session: 'default').last.metadatum.should == @metadatum
+    it 'should retrieve a metadatum for a person detail' do
+      PersonDetail.last.metadatum.should == @metadatum
     end
 
-    it "should retrieve a person's details from the default session for a person in the OpenStates session" do
-      Person.with(session: 'openstates').last.person_detail.should == @record
+    it "should retrieve a person's details for a person" do
+      Person.last.person_detail.should == @record
     end
 
-    it "should retrieve a person from the OpenStates session for a person detail in the default session" do
-      PersonDetail.with(session: 'default').last.person.should == @person
+    it 'should retrieve a person for a person detail' do
+      PersonDetail.last.person.should == @person
     end
   end
 end

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -2,9 +2,9 @@ require 'spec_helper'
 
 describe Person do
   before :each do
-    @metadatum = Metadatum.with(session: 'openstates').create(abbreviation: 'vt')
+    @metadatum = Metadatum.create(abbreviation: 'vt')
     # convoluted setting of id necessary, otherwise id gets generated
-    @person = Person.with(session: 'openstates').new(state: 'vt')
+    @person = Person.new(state: 'vt')
     @person.id = 'VTL000008'
     @person.save!
   end
@@ -12,27 +12,27 @@ describe Person do
   describe '.for_location' do
     it 'returns matching people given a location', :vcr do
       address = '2227 Paine Turnpike South, Berlin, VT'
-      expect(Person.with(session: 'openstates').for_location(address).first).to eq @person
+      expect(Person.for_location(address).first).to eq @person
     end
   end
 
   describe '.load_from_api_for_jurisdiction' do
     it 'does not overwrite existing people' do
-      Person.with(session: 'openstates').load_from_apis_for_jurisdiction('vt')
-      expect(Person.in('vt').count).to eq 1
+      Person.load_from_apis_for_jurisdiction('vt')
+      expect(Person.connected_to('vt').count).to eq 1
     end
 
     # @todo fix collection clearing!!!
     it 'loads people into database given a jurisdiction abbreviation', :vcr do
       # HACK, a simple destroys was not working
-      Mongoid::Sessions.with_name('openstates').collections.each do |collection|
+      Mongoid::Sessions.with_name('default').collections.each do |collection|
         collection.drop
       end
-      @metadatum = Metadatum.with(session: 'openstates').create(abbreviation: 'vt')
+      @metadatum = Metadatum.create(abbreviation: 'vt')
       # END HACK
 
-      Person.with(session: 'openstates').load_from_apis_for_jurisdiction('vt')
-      expect(Person.in('vt').count).to eq 180
+      Person.load_from_apis_for_jurisdiction('vt')
+      expect(Person.connected_to('vt').count).to eq 180
     end
   end
 

--- a/spec/models/project_vote_smart_person_detail_spec.rb
+++ b/spec/models/project_vote_smart_person_detail_spec.rb
@@ -2,10 +2,10 @@ require 'spec_helper'
 
 describe ProjectVoteSmartPersonDetail do
   before :each do
-    @metadatum = Metadatum.with(session: 'openstates').create(abbreviation: 'vt')
+    @metadatum = Metadatum.create(abbreviation: 'vt')
 
     # convoluted setting of id necessary, otherwise id gets generated
-    @person = Person.with(session: 'openstates').new(state: 'vt',
+    @person = Person.new(state: 'vt',
                                                      first_name: 'Ann',
                                                      last_name: 'Cummings',
                                                      district: 'Washington')

--- a/spec/models/question_spec.rb
+++ b/spec/models/question_spec.rb
@@ -30,10 +30,12 @@ describe Question do
   it 'should validate if the bill is blank' do
     expect{FactoryGirl.create(:question, bill: nil)}.to_not raise_error(Mongoid::Errors::Validations)
   end
+
   it 'should validate if the question and the person are in the same jurisdiction' do
     person = FactoryGirl.create(:person)
     expect{FactoryGirl.create(:question, person: person, state: 'anytown')}.to_not raise_error(Mongoid::Errors::Validations)
   end
+
   it 'should not validate if the question and the person are not in the same jurisdiction' do
     metadatum = FactoryGirl.create(:metadatum, abbreviation: 'another')
     person = FactoryGirl.create(:person)
@@ -43,11 +45,13 @@ describe Question do
   it 'should validate if the bill is blank' do
     expect{FactoryGirl.create(:question, bill: nil)}.to_not raise_error(Mongoid::Errors::Validations)
   end
+
   it 'should validate if the person and the bill are in the same jurisdiction' do
     person = FactoryGirl.create(:person)
     bill = FactoryGirl.create(:bill)
     expect{FactoryGirl.create(:question, person: person, bill: bill)}.to_not raise_error(Mongoid::Errors::Validations)
   end
+
   it 'should not validate if the person and the bill are not in the same jurisdiction' do
     metadatum = FactoryGirl.create(:metadatum, abbreviation: 'another')
     person = FactoryGirl.create(:person)
@@ -55,36 +59,36 @@ describe Question do
     expect{FactoryGirl.create(:question, person: person, bill: bill)}.to raise_error(Mongoid::Errors::Validations, /The person and the bill must belong to the same state/)
   end
 
-  context 'with two sessions' do
+  context 'when in relation' do
     before :each do
-      @metadatum = Metadatum.with(session: 'openstates').create(abbreviation: 'zz')
-      @person = Person.with(session: 'openstates').create(state: 'zz')
-      @bill = Bill.with(session: 'openstates').create(state: 'zz', subjects: ['Health'])
+      @metadatum = Metadatum.create(abbreviation: 'zz')
+      @person = Person.create(state: 'zz')
+      @bill = Bill.create(state: 'zz', subjects: ['Health'])
       @question = FactoryGirl.create(:question, person: @person)
       @question_about_bill = FactoryGirl.create(:question, person: @person, bill: @bill)
     end
 
-    it "should retrieve a metadatum from the OpenStates session for a question in the default session" do
-      Question.with(session: 'default').last.metadatum.should == @metadatum
+    it 'should retrieve a metadatum for a question' do
+      Question.last.metadatum.should == @metadatum
     end
 
-    it "should retrieve a question from the default session for a person in the OpenStates session" do
-      Person.with(session: 'openstates').last.questions.should == [@question, @question_about_bill]
+    it 'should retrieve a question for a person' do
+      Person.last.questions.should == [@question, @question_about_bill]
     end
 
-    it "should retrieve a person from the OpenStates session for a question in the default session" do
-      Question.with(session: 'default').last.person.should == @person
+    it 'should retrieve a person for a question' do
+      Question.last.person.should == @person
     end
 
-    it "should retrieve a question from the default session for a bill in the OpenStates session" do
-      Bill.with(session: 'openstates').last.questions.should == [@question_about_bill]
+    it 'should retrieve a question for a bill' do
+      Bill.last.questions.should == [@question_about_bill]
     end
 
-    it "should retrieve a bill from the OpenStates session for a question in the default session" do
-      Question.with(session: 'default').last.bill.should == @bill
+    it 'should retrieve a bill for a question' do
+      Question.last.bill.should == @bill
     end
 
-    it 'should validate if the subject is in the list of subjects in the OpenStates session' do
+    it 'should validate if the subject is in the list of subjects' do
       expect{FactoryGirl.create(:question, person: person, subject: 'Health')}.to_not raise_error(Mongoid::Errors::Validations)
     end
   end

--- a/spec/requests/questions_spec.rb
+++ b/spec/requests/questions_spec.rb
@@ -277,17 +277,17 @@ describe 'questions' do
         @question = FactoryGirl.create(:question,
                                        state: @metadatum.abbreviation,
                                        person: valid_person)
-        visit "/vt/questions/#{@question.id}"
       end
 
       it 'displays number of signatures for question', js: true do
-        pending 'move-to-1-db merged to master'
         FactoryGirl.create(:signature, question: @question)
+        visit "/vt/questions/#{@question.id}"
         signatures_on_page = find('span.question-signatures').text.to_i
         expect(signatures_on_page).to eq @question.signatures.count
       end
 
       it 'displays signature threshold number for recipient', js: true do
+        visit "/vt/questions/#{@question.id}"
         threshold_on_page = find('span.question-signature-threshold').text.to_i
         expect(threshold_on_page).to eq @person.signature_threshold
       end

--- a/spec/requests/questions_spec.rb
+++ b/spec/requests/questions_spec.rb
@@ -2,8 +2,7 @@ require 'spec_helper'
 
 describe 'questions' do
   before :each do
-    @metadatum = Metadatum.with(session: 'openstates')
-      .create(abbreviation: 'vt', chambers: {} )
+    @metadatum = Metadatum.create(abbreviation: 'vt', chambers: {} )
   end
 
   describe '#index' do
@@ -221,8 +220,7 @@ describe 'questions' do
 
   # see models/person_spec for another instance
   def valid_person
-    @person ||= Person.with(session: 'openstates')
-      .new(state: @metadatum.abbreviation)
+    @person ||= Person.new(state: @metadatum.abbreviation)
     @person.id = 'VTL000008'
     @person.save!
     @person


### PR DESCRIPTION
Replace two databases with one database to simplify development and maintenance of application.

We won't want merge this to master until we are ready to migrate our server to support this new architecture. The README steps to set up a development environment also need finishing.
