### PR TITLE
Email sent to elected official when the question reaches it's signature threshold

### DIFF
--- a/app/controllers/signatures_controller.rb
+++ b/app/controllers/signatures_controller.rb
@@ -8,6 +8,13 @@ class SignaturesController < ApplicationController
     if @signature.save
       question = Question.find(params[:question_id])
       QuestionMailer.signed_on(current_user, question).deliver
+      if question.signature_count == question.person.signature_threshold
+        if question.person.email.blank?
+          QuestionMailer.email_person(question, mail_admin=true).deliver
+        else
+          QuestionMailer.email_person(question).deliver
+        end
+      end
       render json: @signature, status: :created
     else
       render json: @signature.errors, status: :unprocessable_entity

--- a/app/mailers/question_mailer.rb
+++ b/app/mailers/question_mailer.rb
@@ -20,7 +20,7 @@ class QuestionMailer < ActionMailer::Base
     @question = question
     @mail_admin = mail_admin
     if mail_admin
-      mail(:to => 'admin@opengovernment.org',
+      mail(:to => 'develop@opengovernment.org',
           :subject => "Error sending email to '#{question.person.name}'")
     else
       mail(:to => question.person.email,

--- a/app/mailers/question_mailer.rb
+++ b/app/mailers/question_mailer.rb
@@ -15,4 +15,16 @@ class QuestionMailer < ActionMailer::Base
     mail(:to => user.email,
         :subject => "You're Signed On to '#{@question.title}'")
   end
+
+  def email_person(question, mail_admin=false)
+    @question = question
+    @mail_admin = mail_admin
+    if mail_admin
+      mail(:to => 'admin@opengovernment.org',
+          :subject => "Error sending email to '#{question.person.name}'")
+    else
+      mail(:to => question.person.email,
+          :subject => "People on AskThem want to know")
+    end
+  end
 end

--- a/app/views/question_mailer/email_person.html.erb
+++ b/app/views/question_mailer/email_person.html.erb
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta content="text/html; charset=UTF-8" http-equiv="Content-Type" />
+  </head>
+  <body>
+    <% if @mail_admin %>
+      <h1 style="color:#f00;">This email could not be sent because we don't have an email address for <%= person_attributes(@question.person) %></h1>
+    <% end %>
+    <h1>A question asked of you by people on AskThem has reached <%= @question.signature_count %> signatures.</h1>
+
+    <dl>
+      <dt>Title</dt>
+      <dd><%= @question.title %></dd>
+
+      <dt>Topic</dt>
+      <dd><%= @question.subject %></dd>
+
+      <dt>Body</dt>
+      <dd><%= @question.body %></dd>
+    </dl>
+
+    <p>
+      <a href="<%= question_url(@question.state, @question.id) %>">Here's a permalink to that question</a>
+    </p>
+    <p>
+        Thank you,
+        The AskThem Team
+    </p>
+  </body>
+</html>

--- a/app/views/question_mailer/email_person.text.erb
+++ b/app/views/question_mailer/email_person.text.erb
@@ -1,0 +1,18 @@
+<% if @mail_admin %>
+  This email could not be sent because we don't have an email address for <%= person_attributes(@question.person) %>
+<% end %>
+A question asked of you by people on AskThem has reached <%= @question.signature_count %> signatures.
+
+Title
+<%= @question.title %>
+
+Topic
+<%= @question.subject %>
+
+Body
+<%= @question.body %>
+
+Here's a permalink to that question: <%= question_url(@question.state, @question.id) %>
+
+Thank you,
+The AskThem Team

--- a/spec/controllers/signature_controller_spec.rb
+++ b/spec/controllers/signature_controller_spec.rb
@@ -1,0 +1,28 @@
+include Devise::TestHelpers
+
+describe SignaturesController do
+  # @warn can't use let because of mongoid teardown
+  before :each do
+    @user = FactoryGirl.create(:user)
+    @person = FactoryGirl.create(:person_ny_sheldon_silver)
+    @question = FactoryGirl.create(:question, person: @person)
+    @question.signature_count = @question.person.signature_threshold - 1
+    @question.save
+    sign_in @user
+  end
+
+  describe "#create" do
+    it "ensures that an email is sent to admins when Person email is blank" do
+      @person.email = ''
+      @person.save
+      post :create, format: :json, question_id: @question.id
+      last_email = ActionMailer::Base.deliveries.last
+      last_email.body.encoded.should match("This email could not be sent because we don't have an email address for")
+    end
+    it "ensures that an email is sent to person when signature threshold is met" do
+      post :create, format: :json, question_id: @question.id
+      last_email = ActionMailer::Base.deliveries.last
+      last_email.body.encoded.should match("A question asked of you by people on AskThem has reached")
+    end
+  end
+end

--- a/spec/mailers/question_mailer_spec.rb
+++ b/spec/mailers/question_mailer_spec.rb
@@ -23,6 +23,19 @@ describe QuestionMailer do
     last_email.from.should == ["develop@opengovernment.org"]
     last_email.subject.should == "You're Signed On to '#{question.title}'"
     last_email.body.encoded.should match(question_url(question.state, question.id))
-
   end
+
+  it "sends an email to a Person when the signature threshold is met" do
+    person = FactoryGirl.create(:person_ny_sheldon_silver)
+    question = FactoryGirl.create(:question, person: person)
+    question.signature_count = question.person.signature_threshold
+    puts "Person Email #{question.person.email}"
+    QuestionMailer.email_person(question).deliver
+    last_email = ActionMailer::Base.deliveries.last
+    last_email.to.should == [question.person.email]
+    last_email.from.should == ["develop@opengovernment.org"]
+    last_email.subject.should == "People on AskThem want to know"
+    last_email.body.encoded.should match(question_url(question.state, question.id))
+  end
+
 end


### PR DESCRIPTION
Relates to #21

If there is no email address present for elected official, an email gets sent to develop@opengovernment.org with a message indicating as much.

Recipient email inbox in this case should probably be revisited.
