### PR TITLE
Sharing modal worked out

### DIFF
--- a/app/views/questions/show.html.erb
+++ b/app/views/questions/show.html.erb
@@ -109,14 +109,6 @@
       <% end %>
       </div>
     <% end %>
-    <h5>Share</h5>
-    <ul>
-       <li>
-         <%= link_to '', "https://www.facebook.com/sharer.php?u=#{URI.escape(current_url)}", class: 'icon-facebook' %>
-         <%= link_to '', "https://twitter.com/share?text=#{URI.escape(@question.title)}", class: 'icon-twitter' %>
-         <%= link_to '', "https://plus.google.com/share?url=#{URI.escape(current_url)}", class: 'icon-google-plus' %>
-       </li>
-    </ul>
     <% if @question.subject? %>
     <h5>Issue Area</h5>
     <ul class="tags">
@@ -129,30 +121,29 @@
   </div>
 </section>
 <% if params[:created] == 'true' %>
-  <!-- this is where the modal will go -->
+  <div id='overlay'></div>
+  <div id='modal'>
+    <div class='modal-content'>
+      <a href='#' class='modal-close'><i class='icon-remove'></i></a>
+      <p class='modal-copy'>Share your question:</p>
+      <a href='mailto:?subject=Help get an answer to my question on AskThem' target="_blank" class='modal-email cta-pill'>
+        <i class='icon-envelope-alt'></i>
+        Email
+      </a>
+      <a href='https://www.facebook.com/sharer.php?u=<%= URI.escape(current_url) %>' target="_blank" class='modal-facebook cta-pill cta-pill-facebook'>
+        <i class='icon-facebook'></i>
+        Facebook
+      </a>
+      <a href='https://twitter.com/share?text=Help get my question answered on AskThem: <%= URI.escape(@question.title) %>' target="_blank" class='modal-twitter cta-pill cta-pill-twitter'>
+        <i class='icon-twitter'></i>
+        Twitter
+      </a>
+    </div>
+  </div>
 <% end %>
 <%# @see http://disqus.com/admin/universalcode/ %>
 
 
-<div id='overlay'></div>
-<div id='modal'>
-  <div class='modal-content'>
-    <a href='#' class='modal-close'><i class='icon-remove'></i></a>
-    <p class='modal-copy'>Share your question:</p>
-    <a href='#' class='modal-email cta-pill'>
-      <i class='icon-envelope-alt'></i>
-      Email
-    </a>
-    <a href='#' class='modal-facebook cta-pill cta-pill-facebook'>
-      <i class='icon-facebook'></i>
-      Facebook
-    </a>
-    <a href='#' class='modal-twitter cta-pill cta-pill-twitter'>
-      <i class='icon-twitter'></i>
-      Twitter
-    </a>
-  </div>
-</div>
 
 <script type="text/javascript">
   var disqus_shortname = 'dobot';

--- a/spec/features/questions_spec.rb
+++ b/spec/features/questions_spec.rb
@@ -304,11 +304,16 @@ describe 'questions' do
         expect(threshold_on_page).to eq @person.signature_threshold
       end
 
+      it 'renders modal when created parameter is present', js: true do
+        visit "/vt/questions/#{@question.id}?created=true"
+        page.body.should have_selector "#modal"
+      end
+
       it 'allows new user to register and sign on to a question', js: true do
         visit "/vt/questions/#{@question.id}"
         fill_in 'user_given_name', with: 'John'
         fill_in 'user_family_name', with: 'Doe'
-        fill_in 'user_email', with: 'john.doe@example.coom'
+        fill_in 'user_email', with: 'john.doe@example.com'
         fill_in 'user_street_address', with: street_address
         fill_in 'user_locality', with: locality
         select_user_region_for('vt')


### PR DESCRIPTION
Added sharing modal into the conditional tag so that it only renders after a new question is created. Added spec to check for the presence of the modal

One thing to note:

The `questions#show` spec `allows new user to register and sign on to a question` is still failing due to the fact that there are two, basically identical, forms on that page when it renders. As far as I could tell, there was no way to disambiguate the two so that the spec filled out and submitted the correct form. What's happening is that it fills out the top one (the one for an elected rep to fill out) and then submits the bottom one (the one for a user to fill out). 

Not sure how you want to handle that so, as of this pull request, that spec is still failing.
