### PR TITLE
Official answer (WIP)

### DIFF
--- a/app/controllers/answers_controller.rb
+++ b/app/controllers/answers_controller.rb
@@ -1,0 +1,13 @@
+class AnswersController < ApplicationController
+  respond_to :html
+  before_filter :authenticate_user!
+
+  def create
+    question = Question.find(params[:question_id])
+    if current_user.has_role?(:responder, question.person)
+      answer = Answer.create!(text: params[:answer][:text], question_id: question.id)
+      redirect_to question_path(question.state, question.id)
+    end
+  end
+end
+

--- a/app/controllers/answers_controller.rb
+++ b/app/controllers/answers_controller.rb
@@ -5,7 +5,11 @@ class AnswersController < ApplicationController
   def create
     question = Question.find(params[:question_id])
     if current_user.has_role?(:responder, question.person)
-      answer = Answer.create!(text: params[:answer][:text], question_id: question.id)
+      answer = Answer.new(text: params[:answer][:text], question_id: question.id)
+      if answer.save!
+        question.answered = true
+        question.save
+      end
       redirect_to question_path(question.state, question.id)
     end
   end

--- a/app/controllers/answers_controller.rb
+++ b/app/controllers/answers_controller.rb
@@ -7,7 +7,7 @@ class AnswersController < ApplicationController
     if current_user.has_role?(:responder, question.person)
       answer = Answer.new(text: params[:answer][:text], question_id: question.id)
       if answer.save!
-        question.answered = true
+        question.answers<<answer
         question.save
       end
       redirect_to question_path(question.state, question.id)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -107,7 +107,7 @@ module ApplicationHelper
     else
       width, height = opts[:width], opts[:height]
     end
-    if url.blank? or url.include? 'ballotpedia'
+    if url.blank? || (url.include? 'ballotpedia')
       image_tag("/assets/placeholder.png")
     else
       image_tag("http://d2xfsikitl0nz3.cloudfront.net/#{CGI.escape(url)}/#{width}/#{height}", opts)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -107,7 +107,7 @@ module ApplicationHelper
     else
       width, height = opts[:width], opts[:height]
     end
-    if url.include? 'ballotpedia'
+    if url.blank? or url.include? 'ballotpedia'
       image_tag("/assets/placeholder.png")
     else
       image_tag("http://d2xfsikitl0nz3.cloudfront.net/#{CGI.escape(url)}/#{width}/#{height}", opts)

--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -1,0 +1,10 @@
+class Answer
+  include Mongoid::Document
+  include Mongoid::Timestamps
+
+  belongs_to :question
+
+  field :text, type: String
+
+  validates_presence_of :text, :question_id
+end

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -9,6 +9,9 @@ class Question
   # The signatures in support of the question.
   has_many :signatures
 
+  # The official answer to the question
+  has_many :answers
+
   # The jurisdiction in which the question is asked.
   field :state, type: String
   # The person to whom the question is addressed.

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -28,9 +28,6 @@ class Question
   field :issued_at, type: Time
   # The number of signatures.
   field :signature_count, type: Integer, default: 0
-  # Whether the question is answered.
-  # @note Use `update_attribute`, not `set`, to trigger the observers.
-  field :answered, type: Boolean, default: false
 
   index(state: 1)
   index(person_id: 1, answered: 1)
@@ -70,6 +67,10 @@ class Question
     else
       self.person_id = nil
     end
+  end
+
+  def answered?
+    self.answers.any?
   end
 
   # @todo delete if unnecessary with only 1 db

--- a/app/views/questions/show.html.erb
+++ b/app/views/questions/show.html.erb
@@ -45,10 +45,10 @@
       <span class="pubdate"><time datetime="2009-11-13" pubdate>November 11th 2013 <sup>6:45pm</sup></time></span>
     </div>
     <a href="#sign_on_q" class="mobile_cta cta-pill">Sign On</a> <%# @todo JM - mobile sign on button, if logged in this button should sign the question, otherwise it should send the user to the anchored form %>
-
+    <% if @user.has_role?(:responder, @question.person) %>
     <div class='recipient-answer-form'>
-      <h2>Sign Up &amp; Answer this Question as <strong>Ron Paul</strong></h2>
-      <h2> (R- 6th House District)</h2>
+      <h2>Answer this Question as <strong><%= @question.person.name %></strong></h2>
+      <h2><%= person_attributes(@question.person) %></h2>
       <%= simple_form_for(@user, as: :user, url: registration_path(:user)) do |f| %>
         <%= hidden_field_tag :question_id, @question.id %>
         <%= f.input :password, placeholder: "What is your answer?", as: :text, label: false %>
@@ -62,6 +62,24 @@
       <% end %>
       <p class='watermark-tip'>This watermark will appear on all answers you post to the OpenGovernment Website, indicating that you are an official representative.</p>
     </div>
+    <% else %>
+    <div class='recipient-answer-form'>
+      <h2>Sign up &amp; Answer this Question as <strong><%= @question.person.name %></strong></h2>
+      <h2><%= person_attributes(@question.person) %></h2>
+      <%= simple_form_for(@user, as: :user, url: registration_path(:user)) do |f| %>
+        <%= hidden_field_tag :question_id, @question.id %>
+        <%= f.input :password, placeholder: "What is your answer?", as: :text, label: false %>
+        <div class='recipient-answer-form-left'>
+          <%= f.input :given_name, placeholder: "First Name", label: false %>
+          <%= f.input :family_name, placeholder: "Last Name", label: false %>
+          <%= f.input :email, placeholder: "Official Gov. E-mail", label: false %>
+          <%= f.input :password, placeholder: "Password", label: false %>
+          <%= f.button :submit, 'Submit Answer', class: 'cta-pill' %>
+        </div>
+      <% end %>
+      <p class='watermark-tip'>This watermark will appear on all answers you post to the OpenGovernment Website, indicating that you are an official representative.</p>
+    </div>
+    <% end %>
     <div class="comments">
       <div id="disqus_thread"></div>
     </div>

--- a/app/views/questions/show.html.erb
+++ b/app/views/questions/show.html.erb
@@ -45,9 +45,8 @@
 
         <span class="pubdate"><time datetime="<%= @question.answers.first.created_at.strftime "%Y-%m-%d" %>" pubdate><%= @question.answers.first.created_at.strftime "%B #{@question.answers.first.created_at.day.ordinalize} %Y" %><sup><%= @question.answers.first.created_at.strftime "%I:%M%p" %></sup></time></span>
       </div>
-    <% else %>
+    <% elsif @user.has_role?(:responder, @question.person)%>
       <!-- <a href="#sign_on_q" class="mobile_cta cta-pill">Sign On</a> <%# @todo JM - mobile sign on button, if logged in this button should sign the question, otherwise it should send the user to the anchored form %> -->
-      <% if @user.has_role?(:responder, @question.person) %>
       <div class='recipient-answer-form'>
         <h2>Answer this Question as <strong><%= @question.person.name %></strong></h2>
         <h2><%= person_attributes(@question.person) %></h2>
@@ -58,24 +57,9 @@
         <% end %>
         <p class='watermark-tip'>This watermark will appear on all answers you post to the OpenGovernment Website, indicating that you are an official representative.</p>
       </div>
-      <% else %>
-      <div class='recipient-answer-form'>
-        <h2>Sign up &amp; Answer this Question as <strong><%= @question.person.name %></strong></h2>
-        <h2><%= person_attributes @question.person %></h2>
-        <%= simple_form_for(:user, url: registration_path(:user)) do |f| %>
-          <%= hidden_field_tag :question_id, @question.id %>
-          <%= f.input :password, placeholder: "What is your answer?", as: :text, label: false %>
-          <div class='recipient-answer-form-left'>
-            <%= f.input :given_name, placeholder: "First Name", label: false %>
-            <%= f.input :family_name, placeholder: "Last Name", label: false %>
-            <%= f.input :email, placeholder: "Official Gov. E-mail", label: false %>
-            <%= f.input :password, placeholder: "Password", label: false %>
-            <%= f.button :submit, 'Submit Answer', class: 'cta-pill' %>
-          </div>
-        <% end %>
-        <p class='watermark-tip'>This watermark will appear on all answers you post to the OpenGovernment Website, indicating that you are an official representative.</p>
-      </div>
-      <% end %>
+    <% elsif not user_signed_in? %>
+      <p>Are you <%= @question.person.name %>?</p>
+      <%= link_to 'Sign up to answer', new_user_registration_path, class: 'cta-pill' %>
     <% end %>
     <div class="comments">
       <div id="disqus_thread"></div>
@@ -108,21 +92,21 @@
           <% end %>
         </li>
       </ul>
-    <%# else %>
-    <!-- <div class="row last signup"> -->
-      <%#= simple_form_for(@user, as: :user, url: registration_path(:user)) do |f| %>
-        <%#= hidden_field_tag :question_id, @question.id %>
-        <%#= f.input :given_name, placeholder: "First Name", label: false %>
-        <%#= f.input :family_name, placeholder: "Last Name", label: false %>
-        <%#= f.input :email, placeholder: "E-mail", label: false %>
-        <%#= f.input :street_address, placeholder: "Street Address", label: false %>
-        <%#= f.input :locality, placeholder: "City", label: false %>
-        <%#= f.input :region, collection: OpenGovernment::STATES, prompt: "Select your state", label: false, wrapper_html: {class: 'icon-angle-down sculpt'} %>
-        <%#= f.input :postal_code, placeholder: "Zip or Postal Code", label: false %>
-        <%#= f.input :password, placeholder: "Password", label: false %>
-        <%#= f.button :submit, 'Sign On', class: 'cta-pill' %>
-      <%# end %>
-      <!-- </div> -->
+    <% else %>
+    <div class="row last signup">
+      <%= simple_form_for(@user, as: :user, url: registration_path(:user)) do |f| %>
+        <%= hidden_field_tag :question_id, @question.id %>
+        <%= f.input :given_name, placeholder: "First Name", label: false %>
+        <%= f.input :family_name, placeholder: "Last Name", label: false %>
+        <%= f.input :email, placeholder: "E-mail", label: false %>
+        <%= f.input :street_address, placeholder: "Street Address", label: false %>
+        <%= f.input :locality, placeholder: "City", label: false %>
+        <%= f.input :region, collection: OpenGovernment::STATES, prompt: "Select your state", label: false, wrapper_html: {class: 'icon-angle-down sculpt'} %>
+        <%= f.input :postal_code, placeholder: "Zip or Postal Code", label: false %>
+        <%= f.input :password, placeholder: "Password", label: false %>
+        <%= f.button :submit, 'Sign On', class: 'cta-pill' %>
+      <% end %>
+      </div>
     <% end %>
     <% if @question.subject? %>
     <h5>Issue Area</h5>

--- a/app/views/questions/show.html.erb
+++ b/app/views/questions/show.html.erb
@@ -28,51 +28,54 @@
       </span>
     </span>
 
-    <div class="recipient_answer recipient"> <%# @todo JM %>
-      <div class="avatar">
-        <img src="http://lorempixel.com/130/130/" alt="" />
-      </div>
-      <div class="person-info">
-        <h2>Steven Trevathan</h2>
-        <span class="jurisdiction">Republican, 6th House District</span>
-        <span class="stats">
-          <span>3 Questions</span>
-          <span>1 Answers</span>
-        </span>
-      </div>
-      <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-
-      <span class="pubdate"><time datetime="2009-11-13" pubdate>November 11th 2013 <sup>6:45pm</sup></time></span>
-    </div>
-    <a href="#sign_on_q" class="mobile_cta cta-pill">Sign On</a> <%# @todo JM - mobile sign on button, if logged in this button should sign the question, otherwise it should send the user to the anchored form %>
-    <% if @user.has_role?(:responder, @question.person) %>
-    <div class='recipient-answer-form'>
-      <h2>Answer this Question as <strong><%= @question.person.name %></strong></h2>
-      <h2><%= person_attributes(@question.person) %></h2>
-      <%= simple_form_for(:answer, url: answers_path) do |f| %>
-        <%= hidden_field_tag :question_id, @question.id %>
-        <%= f.input :text, placeholder: "What is your answer?", as: :text, label: false %>
-        <%= f.button :submit, 'Submit Answer', class: 'cta-pill' %>
-      <% end %>
-      <p class='watermark-tip'>This watermark will appear on all answers you post to the OpenGovernment Website, indicating that you are an official representative.</p>
-    </div>
-    <% else %>
-    <div class='recipient-answer-form'>
-      <h2>Sign up &amp; Answer this Question as <strong><%= @question.person.name %></strong></h2>
-      <h2><%= person_attributes(@question.person) %></h2>
-      <%= simple_form_for(@user, as: :user, url: registration_path(:user)) do |f| %>
-        <%= hidden_field_tag :question_id, @question.id %>
-        <%= f.input :password, placeholder: "What is your answer?", as: :text, label: false %>
-        <div class='recipient-answer-form-left'>
-          <%= f.input :given_name, placeholder: "First Name", label: false %>
-          <%= f.input :family_name, placeholder: "Last Name", label: false %>
-          <%= f.input :email, placeholder: "Official Gov. E-mail", label: false %>
-          <%= f.input :password, placeholder: "Password", label: false %>
-          <%= f.button :submit, 'Submit Answer', class: 'cta-pill' %>
+    <% if @question.answered and not @question.answers.first.nil? %>
+      <div class="recipient_answer recipient">
+        <div class="avatar">
+          <%= cdn_image_tag(@question.person.image, size: '130x130', alt: '') %>
         </div>
+        <div class="person-info">
+          <h2><%= @question.person.name %></h2>
+          <span class="jurisdiction"><%= person_attributes @question.person %></span>
+          <span class="stats">
+            <span><%= pluralize @question.person.questions.length, 'Question' %></span>
+            <span><%= pluralize @question.person.questions_answered.length, 'Answer' %></span>
+          </span>
+        </div>
+        <p><%= @question.answers.first.text %></p>
+
+        <span class="pubdate"><time datetime="<%= @question.answers.first.created_at.strftime "%Y-%m-%d" %>" pubdate><%= @question.answers.first.created_at.strftime "%B #{@question.answers.first.created_at.day.ordinalize} %Y" %><sup><%= @question.answers.first.created_at.strftime "%I:%M%p" %></sup></time></span>
+      </div>
+    <% else %>
+      <!-- <a href="#sign_on_q" class="mobile_cta cta-pill">Sign On</a> <%# @todo JM - mobile sign on button, if logged in this button should sign the question, otherwise it should send the user to the anchored form %> -->
+      <% if @user.has_role?(:responder, @question.person) %>
+      <div class='recipient-answer-form'>
+        <h2>Answer this Question as <strong><%= @question.person.name %></strong></h2>
+        <h2><%= person_attributes(@question.person) %></h2>
+        <%= simple_form_for(:answer, url: answers_path) do |f| %>
+          <%= hidden_field_tag :question_id, @question.id %>
+          <%= f.input :text, placeholder: "What is your answer?", as: :text, label: false %>
+          <%= f.button :submit, 'Submit Answer', class: 'cta-pill' %>
+        <% end %>
+        <p class='watermark-tip'>This watermark will appear on all answers you post to the OpenGovernment Website, indicating that you are an official representative.</p>
+      </div>
+      <% else %>
+      <div class='recipient-answer-form'>
+        <h2>Sign up &amp; Answer this Question as <strong><%= @question.person.name %></strong></h2>
+        <h2><%= person_attributes @question.person %></h2>
+        <%= simple_form_for(@user, as: :user, url: registration_path(:user)) do |f| %>
+          <%= hidden_field_tag :question_id, @question.id %>
+          <%= f.input :password, placeholder: "What is your answer?", as: :text, label: false %>
+          <div class='recipient-answer-form-left'>
+            <%= f.input :given_name, placeholder: "First Name", label: false %>
+            <%= f.input :family_name, placeholder: "Last Name", label: false %>
+            <%= f.input :email, placeholder: "Official Gov. E-mail", label: false %>
+            <%= f.input :password, placeholder: "Password", label: false %>
+            <%= f.button :submit, 'Submit Answer', class: 'cta-pill' %>
+          </div>
+        <% end %>
+        <p class='watermark-tip'>This watermark will appear on all answers you post to the OpenGovernment Website, indicating that you are an official representative.</p>
+      </div>
       <% end %>
-      <p class='watermark-tip'>This watermark will appear on all answers you post to the OpenGovernment Website, indicating that you are an official representative.</p>
-    </div>
     <% end %>
     <div class="comments">
       <div id="disqus_thread"></div>

--- a/app/views/questions/show.html.erb
+++ b/app/views/questions/show.html.erb
@@ -28,7 +28,7 @@
       </span>
     </span>
 
-    <% if @question.answered and not @question.answers.first.nil? %>
+    <% if @question.answered? %>
       <div class="recipient_answer recipient">
         <div class="avatar">
           <%= cdn_image_tag(@question.person.image, size: '130x130', alt: '') %>

--- a/app/views/questions/show.html.erb
+++ b/app/views/questions/show.html.erb
@@ -57,9 +57,11 @@
         <% end %>
         <p class='watermark-tip'>This watermark will appear on all answers you post to the OpenGovernment Website, indicating that you are an official representative.</p>
       </div>
-    <% elsif not user_signed_in? %>
-      <p>Are you <%= @question.person.name %>?</p>
-      <%= link_to 'Sign up to answer', new_user_registration_path, class: 'cta-pill' %>
+    <% elsif !user_signed_in? %>
+      <p>
+        Are you <%= @question.person.name %>?
+        <%= link_to 'Sign up to answer', new_user_registration_path %>.
+      </p>
     <% end %>
     <div class="comments">
       <div id="disqus_thread"></div>

--- a/app/views/questions/show.html.erb
+++ b/app/views/questions/show.html.erb
@@ -49,16 +49,10 @@
     <div class='recipient-answer-form'>
       <h2>Answer this Question as <strong><%= @question.person.name %></strong></h2>
       <h2><%= person_attributes(@question.person) %></h2>
-      <%= simple_form_for(@user, as: :user, url: registration_path(:user)) do |f| %>
+      <%= simple_form_for(:answer, url: answers_path) do |f| %>
         <%= hidden_field_tag :question_id, @question.id %>
-        <%= f.input :password, placeholder: "What is your answer?", as: :text, label: false %>
-        <div class='recipient-answer-form-left'>
-          <%= f.input :given_name, placeholder: "First Name", label: false %>
-          <%= f.input :family_name, placeholder: "Last Name", label: false %>
-          <%= f.input :email, placeholder: "Official Gov. E-mail", label: false %>
-          <%= f.input :password, placeholder: "Password", label: false %>
-          <%= f.button :submit, 'Submit Answer', class: 'cta-pill' %>
-        </div>
+        <%= f.input :text, placeholder: "What is your answer?", as: :text, label: false %>
+        <%= f.button :submit, 'Submit Answer', class: 'cta-pill' %>
       <% end %>
       <p class='watermark-tip'>This watermark will appear on all answers you post to the OpenGovernment Website, indicating that you are an official representative.</p>
     </div>

--- a/app/views/questions/show.html.erb
+++ b/app/views/questions/show.html.erb
@@ -46,10 +46,6 @@
     </div>
     <a href="#sign_on_q" class="mobile_cta cta-pill">Sign On</a> <%# @todo JM - mobile sign on button, if logged in this button should sign the question, otherwise it should send the user to the anchored form %>
 
-    <div class="comments">
-      <div id="disqus_thread"></div>
-    </div>
-
     <div class='recipient-answer-form'>
       <h2>Sign Up &amp; Answer this Question as <strong>Ron Paul</strong></h2>
       <h2> (R- 6th House District)</h2>
@@ -66,6 +62,10 @@
       <% end %>
       <p class='watermark-tip'>This watermark will appear on all answers you post to the OpenGovernment Website, indicating that you are an official representative.</p>
     </div>
+    <div class="comments">
+      <div id="disqus_thread"></div>
+    </div>
+
   </article>
   <a name="sign_on_q"></a>
   <div class="actions">
@@ -93,21 +93,21 @@
           <% end %>
         </li>
       </ul>
-    <% else %>
-      <div class="row last signup">
-      <%= simple_form_for(@user, as: :user, url: registration_path(:user)) do |f| %>
-        <%= hidden_field_tag :question_id, @question.id %>
-        <%= f.input :given_name, placeholder: "First Name", label: false %>
-        <%= f.input :family_name, placeholder: "Last Name", label: false %>
-        <%= f.input :email, placeholder: "E-mail", label: false %>
-        <%= f.input :street_address, placeholder: "Street Address", label: false %>
-        <%= f.input :locality, placeholder: "City", label: false %>
-        <%= f.input :region, collection: OpenGovernment::STATES, prompt: "Select your state", label: false, wrapper_html: {class: 'icon-angle-down sculpt'} %>
-        <%= f.input :postal_code, placeholder: "Zip or Postal Code", label: false %>
-        <%= f.input :password, placeholder: "Password", label: false %>
-        <%= f.button :submit, 'Sign On', class: 'cta-pill' %>
-      <% end %>
-      </div>
+    <%# else %>
+    <!-- <div class="row last signup"> -->
+      <%#= simple_form_for(@user, as: :user, url: registration_path(:user)) do |f| %>
+        <%#= hidden_field_tag :question_id, @question.id %>
+        <%#= f.input :given_name, placeholder: "First Name", label: false %>
+        <%#= f.input :family_name, placeholder: "Last Name", label: false %>
+        <%#= f.input :email, placeholder: "E-mail", label: false %>
+        <%#= f.input :street_address, placeholder: "Street Address", label: false %>
+        <%#= f.input :locality, placeholder: "City", label: false %>
+        <%#= f.input :region, collection: OpenGovernment::STATES, prompt: "Select your state", label: false, wrapper_html: {class: 'icon-angle-down sculpt'} %>
+        <%#= f.input :postal_code, placeholder: "Zip or Postal Code", label: false %>
+        <%#= f.input :password, placeholder: "Password", label: false %>
+        <%#= f.button :submit, 'Sign On', class: 'cta-pill' %>
+      <%# end %>
+      <!-- </div> -->
     <% end %>
     <% if @question.subject? %>
     <h5>Issue Area</h5>

--- a/app/views/questions/show.html.erb
+++ b/app/views/questions/show.html.erb
@@ -62,7 +62,7 @@
       <div class='recipient-answer-form'>
         <h2>Sign up &amp; Answer this Question as <strong><%= @question.person.name %></strong></h2>
         <h2><%= person_attributes @question.person %></h2>
-        <%= simple_form_for(@user, as: :user, url: registration_path(:user)) do |f| %>
+        <%= simple_form_for(:user, url: registration_path(:user)) do |f| %>
           <%= hidden_field_tag :question_id, @question.id %>
           <%= f.input :password, placeholder: "What is your answer?", as: :text, label: false %>
           <div class='recipient-answer-form-left'>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,7 @@ OpenGovernment::Application.routes.draw do
 
   resources :users, only: :show
   resources :signatures, only: :create
+  resources :answers, only: :create
 
   resources :identities, only: :update
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -30,7 +30,6 @@ FactoryGirl.define do
       last_name "Silver"
       full_name "Sheldon Silver"
       email "speaker@assembly.state.ny.us"
-      image "http:///photos/federal/100x125/A000055.jpg"
       metadatum { FactoryGirl.create(:metadatum, abbreviation: "ny") }
     end
   end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -30,6 +30,7 @@ FactoryGirl.define do
       last_name "Silver"
       full_name "Sheldon Silver"
       email "speaker@assembly.state.ny.us"
+      image "http:///photos/federal/100x125/A000055.jpg"
       metadatum { FactoryGirl.create(:metadatum, abbreviation: "ny") }
     end
   end
@@ -77,6 +78,7 @@ FactoryGirl.define do
         record.bill = FactoryGirl.create(:bill) unless record.bill_id?
       end
     end
+
   end
 
   factory :signature do

--- a/spec/features/answers_spec.rb
+++ b/spec/features/answers_spec.rb
@@ -1,0 +1,43 @@
+require 'spec_helper'
+require File.expand_path("../features_helper.rb", __FILE__)
+
+describe 'question' do
+  before :each do
+    @user = FactoryGirl.create(:user)
+    @metadatum = Metadatum.create(name: 'New York',
+                                  abbreviation: 'ny',
+                                  chambers: {} )
+    @person = FactoryGirl.create(:person_ny_sheldon_silver)
+    @question = FactoryGirl.create(:question,
+                                   state: @metadatum.abbreviation,
+                                   person: @person)
+    identity = FactoryGirl.create(:identity)
+    identity.status = 'being_inspected'
+    identity.verify! @user
+    @verified_user = User.find(identity.user_id)
+  end
+
+  describe '#show' do
+    context 'when signed in as responder' do
+
+      it 'allows that user to respond to the question' do
+        as_user @verified_user do
+          visit "/ny/questions/#{@question.id}"
+          find(".btn.cta-pill").value.should eq 'Submit Answer'
+        end
+      end
+
+      it 'displays the answer' do
+        as_user @verified_user do
+          visit "/ny/questions/#{@question.id}"
+          within '.answer' do
+            fill_in 'answer[text]', :with => 'Very interesting question, let me think about it.'
+            click_button 'Submit Answer'
+          end
+          page.body.should have_content 'Very interesting question, let me think about it.'
+        end
+      end
+
+    end
+  end
+end

--- a/spec/features/questions_spec.rb
+++ b/spec/features/questions_spec.rb
@@ -317,23 +317,23 @@ describe 'questions' do
         page.body.should have_selector "#modal"
       end
 
-     #it 'allows new user to register and sign on to a question', js: true do
-     #  visit "/vt/questions/#{@question.id}"
+      it 'allows new user to register and sign on to a question', js: true do
+        visit "/vt/questions/#{@question.id}"
 
-     #  within ".signup" do
-     #    fill_in 'user_given_name', with: 'John'
-     #    fill_in 'user_family_name', with: 'Doe'
-     #    fill_in 'user_email', with: 'john.doe@example.com'
-     #    fill_in 'user_street_address', with: street_address
-     #    fill_in 'user_locality', with: locality
-     #    select_user_region_for('vt')
-     #    fill_in 'user_postal_code', with: postal_code
-     #    fill_in 'user_password', with: 'testtest'
-     #    click_button 'Sign On'
-     #  end
+        within ".signup" do
+          fill_in 'user_given_name', with: 'John'
+          fill_in 'user_family_name', with: 'Doe'
+          fill_in 'user_email', with: 'john.doe@example.com'
+          fill_in 'user_street_address', with: street_address
+          fill_in 'user_locality', with: locality
+          select_user_region_for('vt')
+          fill_in 'user_postal_code', with: postal_code
+          fill_in 'user_password', with: 'testtest'
+          click_button 'Sign On'
+        end
 
-     #  page.body.should have_content '1 out of'
-     #end
+        page.body.should have_content '1 out of'
+      end
 
       context 'as signed in user' do
         it 'allows user to sign on to a question', js: true do

--- a/spec/features/questions_spec.rb
+++ b/spec/features/questions_spec.rb
@@ -55,6 +55,7 @@ describe 'questions' do
           end
         end
       end
+
     end
   end
 
@@ -316,23 +317,23 @@ describe 'questions' do
         page.body.should have_selector "#modal"
       end
 
-      it 'allows new user to register and sign on to a question', js: true do
-        visit "/vt/questions/#{@question.id}"
+     #it 'allows new user to register and sign on to a question', js: true do
+     #  visit "/vt/questions/#{@question.id}"
 
-        within ".signup" do
-          fill_in 'user_given_name', with: 'John'
-          fill_in 'user_family_name', with: 'Doe'
-          fill_in 'user_email', with: 'john.doe@example.com'
-          fill_in 'user_street_address', with: street_address
-          fill_in 'user_locality', with: locality
-          select_user_region_for('vt')
-          fill_in 'user_postal_code', with: postal_code
-          fill_in 'user_password', with: 'testtest'
-          click_button 'Sign On'
-        end
+     #  within ".signup" do
+     #    fill_in 'user_given_name', with: 'John'
+     #    fill_in 'user_family_name', with: 'Doe'
+     #    fill_in 'user_email', with: 'john.doe@example.com'
+     #    fill_in 'user_street_address', with: street_address
+     #    fill_in 'user_locality', with: locality
+     #    select_user_region_for('vt')
+     #    fill_in 'user_postal_code', with: postal_code
+     #    fill_in 'user_password', with: 'testtest'
+     #    click_button 'Sign On'
+     #  end
 
-        page.body.should have_content '1 out of'
-      end
+     #  page.body.should have_content '1 out of'
+     #end
 
       context 'as signed in user' do
         it 'allows user to sign on to a question', js: true do
@@ -345,6 +346,7 @@ describe 'questions' do
           end
         end
       end
+
     end
   end
 

--- a/spec/models/answer_spec.rb
+++ b/spec/models/answer_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+
+describe Answer do
+  %w(text question_id).each do |attribute|
+    it {should validate_presence_of attribute}
+  end
+end

--- a/spec/models/question_spec.rb
+++ b/spec/models/question_spec.rb
@@ -99,5 +99,11 @@ describe Question do
       # should not raise Mongoid::Errors::Validations
       expect{FactoryGirl.create(:question, person: @person, subject: 'Health')}.to_not raise_error
     end
+
+    it 'should answer a question' do
+      Answer.create(text: 'This is the answer to the question', question: @question)
+      expect(@question.answered?).to be_true
+    end
+
   end
 end


### PR DESCRIPTION
Verified officials can submit answers to questions asked of them and those answers are shown on the question page.
### Added features:
- Created Answer model and spec
- Created AnswersController to handle create method, verifying answer can only come from the correct verified official
- Rendering answer on question #show
- Created simple answer submission form when official is already signed in
- Hiding answer submission form when question has been answered
### Todo:
- spec for proper answered boolean behavior when question submitted
- feature spec for submitting and rendering answers
### Work in progress (WIP)

@walter & @davidmooreppf this pull request is still a WIP, but wanted to push this up so you could take a look at our progress so far. A few notes:
- Noticed there was no model for storing answers, so we stubbed one out. @evz and I weren't sure if we wanted to support more than one answer, so we hedged on the model supporting it. 
- What should we do with the Sign On buttons once a question has been answered? Keep it active?
- What if an official answers a question _before_ a it reaches the signature threshold? Do we have a story for this?
- Now that we're showing answers, we need some styles to indicate a question has been answered on the question #index and #show views. 
