### PR TITLE
Use HTTPS for Sunlight Congress API interaction

### DIFF
--- a/app/services/sunlight_congress_legislator_service.rb
+++ b/app/services/sunlight_congress_legislator_service.rb
@@ -10,7 +10,7 @@ class SunlightCongressLegislatorService
 
   def initialize
     @key = ENV['SUNLIGHT_API_KEY']
-    @base_url = "http://congress.api.sunlightfoundation.com/"
+    @base_url = "https://congress.api.sunlightfoundation.com/"
     @legislators_url = "#{base_url}legislators/"
     @id_field = "bioguide_id"
   end


### PR DESCRIPTION
Sunlight recently began [encrypting our Congress API by default](http://sunlightfoundation.com/blog/2014/01/28/encrypting-our-congress-api-and-protecting-your-location/), and are strongly recommend use of our `https://` endpoint. This is especially true for queries containing latitude and longitude, which askthem.io does.
