### PR TITLE
Reduce padding for zip code input

### DIFF
--- a/public/widgets/zip/widget.css
+++ b/public/widgets/zip/widget.css
@@ -41,7 +41,7 @@
   -moz-border-radius: 5px;
   border-radius: 5px;
   border: 1px solid #d3d9de;
-  padding: 15px 10px;
+  padding: 5px 10px;
 }
 
 .at-widget .zip {


### PR DESCRIPTION
This addresses an issue In firefox where the padding limits the display of the zip code input.
## Without fix:

![screen shot 2015-01-14 at 9 51 03 pm](https://cloud.githubusercontent.com/assets/775600/5752273/c8590c18-9c37-11e4-84f9-03b4e8add246.png)
![screen shot 2015-01-14 at 9 50 47 pm](https://cloud.githubusercontent.com/assets/775600/5752272/c8575e90-9c37-11e4-9075-164592a838c7.png)
## With fix:

![screen shot 2015-01-14 at 9 50 23 pm](https://cloud.githubusercontent.com/assets/775600/5752274/c85b37d6-9c37-11e4-99a5-e6689bc23349.png)

Fixes #420
